### PR TITLE
fix mapping icon after FA update

### DIFF
--- a/view/solr/admin/node/browse.phtml
+++ b/view/solr/admin/node/browse.phtml
@@ -64,7 +64,7 @@
                                 <?php
                                     $href = $node->mappingUrl();
                                     echo $this->hyperlink('', $href, [
-                                        'class' => 'o-icon- fa fa-sliders',
+                                        'class' => 'o-icon- fa fa-sliders-h',
                                         'title' => $this->translate('Mapping'),
                                     ]);
                                 ?>


### PR DESCRIPTION
turn `fa-sliders` into `fa-sliders-h`

SInce omeka-s v1.1.0, Font Awesome has been updated to v5 and some icons have been renamed.
https://fontawesome.com/how-to-use/upgrading-from-4