### PR TITLE
Add ability to index content of text files

### DIFF
--- a/src/ValueExtractor/ItemValueExtractor.php
+++ b/src/ValueExtractor/ItemValueExtractor.php
@@ -84,7 +84,7 @@ class ItemValueExtractor implements ValueExtractorInterface
             ],
         ];
         $fields['media']['label'] = 'Media';
-        $fields['media']['children']['content']['label'] = 'HTML Content';
+        $fields['media']['children']['content']['label'] = 'Text Content';
 
         foreach ($properties as $property) {
             $term = $property->term();
@@ -138,10 +138,14 @@ class ItemValueExtractor implements ValueExtractorInterface
 
         foreach ($item->media() as $media) {
             if ($field === 'content') {
-                if ($media->ingester() !== 'html') {
+                if ($media->ingester() === 'html') {
+                    $mediaExtractedValue = [$media->mediaData()['html']];
+                } elseif ( explode('/', $media->mediaType())[0] === 'text' ) {
+                    $filePath = __DIR__.'/../../../../files/original/'.$media->filename();
+                    $mediaExtractedValue = [file_get_contents($filePath)];
+                } else {
                     continue;
                 }
-                $mediaExtractedValue = [$media->mediaData()['html']];
             } else {
                 $mediaExtractedValue = $this->extractPropertyValue($media, $field);
             }


### PR DESCRIPTION
Many textual medias, including HTML files, are ingested as files. This contribution allow their content to be indexed as HTML media content can be.

To get file path, I’ve used `__DIR__` since `MediaRepresentation::originalUrl()` gives an absolute URL which doesn’t work in context of CLI SAPI.