### PR TITLE
Fix Querier::escapeRegexp so that it also escapes Solr special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed Querier::escapeRegexp so that it also escapes Solr special characters
+
 ## [0.9.3] - 2022-10-27
 
 ### Fixed


### PR DESCRIPTION
This fix a problem when using the "matches pattern" operator with a double quote in the pattern