### PR TITLE
Add ability to index content of text files

### DIFF
--- a/src/ValueExtractor/ItemValueExtractor.php
+++ b/src/ValueExtractor/ItemValueExtractor.php
@@ -84,7 +84,7 @@ class ItemValueExtractor extends AbstractValueExtractor
             ],
         ];
         $fields['media']['label'] = 'Media';
-        $fields['media']['children']['content']['label'] = 'HTML Content';
+        $fields['media']['children']['content']['label'] = 'Text Content';
 
         foreach ($properties as $property) {
             $term = $property->term();
@@ -149,10 +149,14 @@ class ItemValueExtractor extends AbstractValueExtractor
 
         foreach ($item->media() as $media) {
             if ($field === 'content') {
-                if ($media->ingester() !== 'html') {
+                if ($media->ingester() === 'html') {
+                    $mediaExtractedValue = [$media->mediaData()['html']];
+                } elseif (explode('/', $media->mediaType())[0] === 'text') {
+                    $fileURL = $media->originalUrl();
+                    $mediaExtractedValue = [file_get_contents($fileURL)];
+                } else {
                     continue;
                 }
-                $mediaExtractedValue = [$media->mediaData()['html']];
             } else {
                 $mediaExtractedValue = $media->value($field, ['all' => true, 'default' => []]);
             }


### PR DESCRIPTION
Many textual medias, including HTML files, are ingested as files. This PR allows their content to be indexed in the same way current HTML media content can be indexed.

Revival of #12 with fixed wrongly constant file path. I don’t know why I wrote “absolute URL […] doesn’t work in context of CLI SAPI”: I just tested locally, and that seems to work fine.

I did not test with AnyCloud, but `Media->originalUrl()` should include eventual necessary tokens if they are GET params.