### PR TITLE
Allow unlimited facet if facet limit is explicitely set to null

### DIFF
--- a/src/Querier.php
+++ b/src/Querier.php
@@ -166,7 +166,7 @@ class Querier extends AbstractQuerier
                 if (!$solrFacetField) {
                     throw new QuerierException(sprintf('Field %s is not facetable', $facetField));
                 }
-                $solrQuery->setFacetLimit($solrFacetField, $facetLimit);
+                $solrQuery->setFacetLimit($solrFacetField, $facetLimit ?? -1);
             }
         }
 


### PR DESCRIPTION
This is required for the new glossary page block of Search

See: https://github.com/biblibre/omeka-s-module-Search/pull/45